### PR TITLE
fix: invalid view of empty lessons

### DIFF
--- a/lib/common/utils/schedule_utils.dart
+++ b/lib/common/utils/schedule_utils.dart
@@ -21,9 +21,9 @@ class ScheduleUtils {
         "14:20": 4,
         "16:20": 5,
         "18:00": 6,
-        "19:40": 7,
         "18:30": 7,
-        "20:10": 8,
+        "19:40": 8,
+        "20:10": 9,
       };
 
   static Map<String, int> get universityTimesEnd => const {
@@ -33,9 +33,9 @@ class ScheduleUtils {
         "15:50": 4,
         "17:50": 5,
         "19:30": 6,
-        "21:00": 7,
         "20:00": 7,
-        "21:40": 8,
+        "21:00": 8,
+        "21:40": 9,
       };
 
   static bool isCollegeGroup(String group) {


### PR DESCRIPTION
Насколько я понял, настройка с номером пары - легаси, поэтому таким образом легко фиксится текущее невалидное отображение пустых пар. А еще местами поменял, потому что так они вроде в порядке времени начала пары отсортированы